### PR TITLE
Changes to propagation level and detach events

### DIFF
--- a/wicket-cdi/src/main/java/net/ftlines/wicket/cdi/CdiConfiguration.java
+++ b/wicket-cdi/src/main/java/net/ftlines/wicket/cdi/CdiConfiguration.java
@@ -48,6 +48,17 @@ public class CdiConfiguration
 		return beanManager;
 	}
 
+	public ConversationPropagation getPropagation()
+	{
+		return propagation;
+	}
+
+	public CdiConfiguration setPropagation(ConversationPropagation propagation)
+	{
+		this.propagation = propagation;
+		return this;
+	}
+
 	/**
 	 * Configures the specified application
 	 * 
@@ -58,7 +69,8 @@ public class CdiConfiguration
 	{
 		if (beanManager == null)
 		{
-			throw new IllegalStateException("Configuration does not have a BeanManager instance configured");
+			throw new IllegalStateException(
+				"Configuration does not have a BeanManager instance configured");
 		}
 
 		CdiContainer container = new CdiContainer(beanManager);
@@ -66,9 +78,10 @@ public class CdiConfiguration
 
 		application.getComponentInstantiationListeners().add(new CdiInjector(container));
 
-		if (propagation != ConversationPropagation.NONE)
+		if (getPropagation() != ConversationPropagation.NONE)
 		{
-			application.getRequestCycleListeners().add(new ConversationPropagator(container, propagation));
+			application.getRequestCycleListeners().add(
+				new ConversationPropagator(container, getPropagation()));
 		}
 
 		return container;

--- a/wicket-cdi/src/main/java/net/ftlines/wicket/cdi/ConversationPropagator.java
+++ b/wicket-cdi/src/main/java/net/ftlines/wicket/cdi/ConversationPropagator.java
@@ -18,6 +18,7 @@ package net.ftlines.wicket.cdi;
 
 import javax.enterprise.context.Conversation;
 import javax.enterprise.context.ConversationScoped;
+import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
 import org.apache.wicket.MetaDataKey;
@@ -57,6 +58,9 @@ public class ConversationPropagator extends AbstractRequestCycleListener
 
 	@Inject
 	Conversation conversation_;
+	
+	@Inject
+	private Event<Detach> detachEvent;
 
 	/**
 	 * Constructor
@@ -168,6 +172,7 @@ public class ConversationPropagator extends AbstractRequestCycleListener
 	@Override
 	public void onDetach(RequestCycle cycle)
 	{
+		detachEvent.fire(new Detach());
 		if (getConversation(cycle) != null)
 		{
 			container.deactivateConversationalContext(cycle);

--- a/wicket-cdi/src/main/java/net/ftlines/wicket/cdi/Detach.java
+++ b/wicket-cdi/src/main/java/net/ftlines/wicket/cdi/Detach.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package net.ftlines.wicket.cdi;
 
 public class Detach

--- a/wicket-cdi/src/main/java/net/ftlines/wicket/cdi/Detach.java
+++ b/wicket-cdi/src/main/java/net/ftlines/wicket/cdi/Detach.java
@@ -1,0 +1,6 @@
+package net.ftlines.wicket.cdi;
+
+public class Detach
+{
+
+}


### PR DESCRIPTION
These changes make it possible to change the propagation to ALL and a Detach event is now fired directly before ending the conversation scope, making it possible to detach models in beans.
