### PR TITLE
Fix for issue #11

### DIFF
--- a/wicket-cdi/src/main/java/net/ftlines/wicket/cdi/CdiConfiguration.java
+++ b/wicket-cdi/src/main/java/net/ftlines/wicket/cdi/CdiConfiguration.java
@@ -138,8 +138,12 @@ public class CdiConfiguration
 				"Configuration does not have a BeanManager instance configured");
 		}
 
-		CdiContainer container = new CdiContainer(beanManager, nonContextualManager, getPropagation());
+		CdiContainer container = new CdiContainer(beanManager, nonContextualManager,
+			getPropagation());
 		container.bind(application);
+
+		application.getComponentPreOnBeforeRenderListeners().add(
+			new CheckConversationRenderListener(container));
 
 		RequestCycleListenerCollection listeners = new RequestCycleListenerCollection();
 		application.getRequestCycleListeners().add(listeners);

--- a/wicket-cdi/src/main/java/net/ftlines/wicket/cdi/CdiContainer.java
+++ b/wicket-cdi/src/main/java/net/ftlines/wicket/cdi/CdiContainer.java
@@ -20,7 +20,6 @@ import javax.enterprise.inject.spi.BeanManager;
 import javax.servlet.http.HttpServletRequest;
 
 import org.apache.wicket.Application;
-import org.apache.wicket.Component;
 import org.apache.wicket.MetaDataKey;
 import org.apache.wicket.Page;
 import org.apache.wicket.request.cycle.RequestCycle;

--- a/wicket-cdi/src/main/java/net/ftlines/wicket/cdi/CheckConversationRenderListener.java
+++ b/wicket-cdi/src/main/java/net/ftlines/wicket/cdi/CheckConversationRenderListener.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.ftlines.wicket.cdi;
+
+import javax.enterprise.context.Conversation;
+import javax.inject.Inject;
+
+import org.apache.wicket.Component;
+import org.apache.wicket.Page;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.application.IComponentOnBeforeRenderListener;
+import org.apache.wicket.request.cycle.RequestCycle;
+import org.apache.wicket.util.lang.Objects;
+
+public class CheckConversationRenderListener implements IComponentOnBeforeRenderListener
+{
+	@Inject
+	private Conversation conversation;
+
+	public CheckConversationRenderListener(CdiContainer container)
+	{
+		container.getNonContextualManager().inject(this);
+	}
+
+	@Override
+	public void onBeforeRender(Component component)
+	{
+		if (component instanceof Page || AjaxRequestTarget.get() != null)
+		{
+			Page page = component.getPage();
+			String cid = page.getMetaData(ConversationPropagator.CID_KEY);
+			if (cid != null && !Objects.isEqual(conversation.getId(), cid))
+				throw new ConversationExpiredException(null, cid, page, RequestCycle.get()
+					.getActiveRequestHandler());
+		}
+	}
+}

--- a/wicket-cdi/src/main/java/net/ftlines/wicket/cdi/ConversationExpiredException.java
+++ b/wicket-cdi/src/main/java/net/ftlines/wicket/cdi/ConversationExpiredException.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.ftlines.wicket.cdi;
+
+import org.apache.wicket.Page;
+import org.apache.wicket.request.IRequestHandler;
+
+public class ConversationExpiredException extends RuntimeException
+{
+	private String cid;
+	private Page page;
+	private IRequestHandler handler;
+
+	public ConversationExpiredException(Throwable cause, String cid, Page page,
+		IRequestHandler handler)
+	{
+		super(cause);
+		this.cid = cid;
+		this.page = page;
+		this.handler = handler;
+	}
+
+	public String getCid()
+	{
+		return cid;
+	}
+
+	public Page getPage()
+	{
+		return page;
+	}
+
+	public IRequestHandler getHandler()
+	{
+		return handler;
+	}
+}


### PR DESCRIPTION
With this patch, the exception for non-existent conversations is caught. This allows wicket to load the old page, starting a new conversation if needed.
