### PR TITLE
Allow precise specification of when to and when not to propagate conversations

### DIFF
--- a/wicket-cdi/src/main/java/net/ftlines/wicket/cdi/CdiConfiguration.java
+++ b/wicket-cdi/src/main/java/net/ftlines/wicket/cdi/CdiConfiguration.java
@@ -32,7 +32,7 @@ import org.jboss.seam.conversation.spi.SeamConversationContextFactory;
 public class CdiConfiguration
 {
 	private BeanManager beanManager;
-	private ConversationPropagation propagation = ConversationPropagation.NONBOOKMARKABLE;
+	private IConversationPropagation propagation = ConversationPropagation.NONBOOKMARKABLE;
 	private INonContextualManager nonContextualManager;
 
 	private boolean injectComponents = true;
@@ -59,12 +59,12 @@ public class CdiConfiguration
 		return beanManager;
 	}
 
-	public ConversationPropagation getPropagation()
+	public IConversationPropagation getPropagation()
 	{
 		return propagation;
 	}
 
-	public CdiConfiguration setPropagation(ConversationPropagation propagation)
+	public CdiConfiguration setPropagation(IConversationPropagation propagation)
 	{
 		this.propagation = propagation;
 		return this;

--- a/wicket-cdi/src/main/java/net/ftlines/wicket/cdi/ConversationExpiryChecker.java
+++ b/wicket-cdi/src/main/java/net/ftlines/wicket/cdi/ConversationExpiryChecker.java
@@ -25,6 +25,8 @@ import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.application.IComponentOnBeforeRenderListener;
 import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.util.lang.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Checks for conversation expiration during page render and throws a
@@ -38,6 +40,8 @@ import org.apache.wicket.util.lang.Objects;
  */
 public class ConversationExpiryChecker implements IComponentOnBeforeRenderListener
 {
+	private static final Logger logger = LoggerFactory.getLogger(ConversationExpiryChecker.class);
+	
 	@Inject
 	private Conversation conversation;
 
@@ -58,8 +62,11 @@ public class ConversationExpiryChecker implements IComponentOnBeforeRenderListen
 			Page page = component.getPage();
 			String cid = container.getConversationMarker(page);
 			if (cid != null && !Objects.isEqual(conversation.getId(), cid))
+			{
+				logger.info("Conversation {} has expired for {}", cid, page);
 				throw new ConversationExpiredException(null, cid, page, RequestCycle.get()
 					.getActiveRequestHandler());
+			}
 		}
 	}
 }

--- a/wicket-cdi/src/main/java/net/ftlines/wicket/cdi/ConversationPropagation.java
+++ b/wicket-cdi/src/main/java/net/ftlines/wicket/cdi/ConversationPropagation.java
@@ -18,6 +18,7 @@ package net.ftlines.wicket.cdi;
 
 import javax.enterprise.context.ConversationScoped;
 
+import org.apache.wicket.Page;
 import org.apache.wicket.request.IRequestHandler;
 
 /**
@@ -31,7 +32,7 @@ public enum ConversationPropagation implements IConversationPropagation {
 	/** No conversational propagation takes place */
 	NONE {
 		@Override
-		public boolean propagatesViaPage(IRequestHandler handler)
+		public boolean propagatesViaPage(Page page, IRequestHandler handler)
 		{
 			return false;
 		}
@@ -47,7 +48,7 @@ public enum ConversationPropagation implements IConversationPropagation {
 	 */
 	NONBOOKMARKABLE {
 		@Override
-		public boolean propagatesViaPage(IRequestHandler handler)
+		public boolean propagatesViaPage(Page page, IRequestHandler handler)
 		{
 			return true;
 		}
@@ -63,7 +64,7 @@ public enum ConversationPropagation implements IConversationPropagation {
 	 */
 	ALL {
 		@Override
-		public boolean propagatesViaPage(IRequestHandler handler)
+		public boolean propagatesViaPage(Page page, IRequestHandler handler)
 		{
 			return true;
 		}

--- a/wicket-cdi/src/main/java/net/ftlines/wicket/cdi/ConversationPropagation.java
+++ b/wicket-cdi/src/main/java/net/ftlines/wicket/cdi/ConversationPropagation.java
@@ -18,6 +18,8 @@ package net.ftlines.wicket.cdi;
 
 import javax.enterprise.context.ConversationScoped;
 
+import org.apache.wicket.request.IRequestHandler;
+
 /**
  * Various modes of propagating persistent conversations across requests.
  * 
@@ -25,15 +27,51 @@ import javax.enterprise.context.ConversationScoped;
  * 
  * @author igor
  */
-public enum ConversationPropagation {
+public enum ConversationPropagation implements IConversationPropagation {
 	/** No conversational propagation takes place */
-	NONE,
+	NONE {
+		@Override
+		public boolean propagatesViaPage(IRequestHandler handler)
+		{
+			return false;
+		}
+
+		@Override
+		public boolean propagatesViaParameters(IRequestHandler handler)
+		{
+			return false;
+		}
+	},
 	/**
 	 * Pesistent conversations are propagated between non-bookmarkable pages only
 	 */
-	NONBOOKMARKABLE,
+	NONBOOKMARKABLE {
+		@Override
+		public boolean propagatesViaPage(IRequestHandler handler)
+		{
+			return true;
+		}
+
+		@Override
+		public boolean propagatesViaParameters(IRequestHandler handler)
+		{
+			return false;
+		}
+	},
 	/**
 	 * Persistent conversations are propagated between bookmarkable and non-bookmarkable pages
 	 */
-	ALL;
+	ALL {
+		@Override
+		public boolean propagatesViaPage(IRequestHandler handler)
+		{
+			return true;
+		}
+
+		@Override
+		public boolean propagatesViaParameters(IRequestHandler handler)
+		{
+			return true;
+		}
+	};
 }

--- a/wicket-cdi/src/main/java/net/ftlines/wicket/cdi/IConversationPropagation.java
+++ b/wicket-cdi/src/main/java/net/ftlines/wicket/cdi/IConversationPropagation.java
@@ -16,11 +16,36 @@
  */
 package net.ftlines.wicket.cdi;
 
+import org.apache.wicket.Page;
 import org.apache.wicket.request.IRequestHandler;
 
+/**
+ * A strategy that specifies how conversations should be propagated between pages/resources.
+ * {@link ConversationPropagation} provides sensible default implementations of this interface.
+ * 
+ * @author papegaaij
+ */
 public interface IConversationPropagation
 {
-	public boolean propagatesViaPage(IRequestHandler handler);
+	/**
+	 * Indicates if the conversation should be propagated via page metadata (on an instance) for the
+	 * given page and request handler.
+	 * 
+	 * @param page
+	 *            The page on which the tag will be set.
+	 * @param handler
+	 *            The current request handler
+	 * @return true if the conversation should be propagated to the given page instance.
+	 */
+	public boolean propagatesViaPage(Page page, IRequestHandler handler);
 
+	/**
+	 * Indicates if the conversation should be propagated via url-parameters for the given request
+	 * handler. This can either be a get parameter in a rendered url, or via page parameters.
+	 * 
+	 * @param handler
+	 *            The current request handler
+	 * @return true if the conversation should be propagated for the given request handler.
+	 */
 	public boolean propagatesViaParameters(IRequestHandler handler);
 }

--- a/wicket-cdi/src/main/java/net/ftlines/wicket/cdi/IConversationPropagation.java
+++ b/wicket-cdi/src/main/java/net/ftlines/wicket/cdi/IConversationPropagation.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.ftlines.wicket.cdi;
+
+import org.apache.wicket.request.IRequestHandler;
+
+public interface IConversationPropagation
+{
+	public boolean propagatesViaPage(IRequestHandler handler);
+
+	public boolean propagatesViaParameters(IRequestHandler handler);
+}


### PR DESCRIPTION
We ran into a problem where the current ConversationPropagation enum does not offer enough flexibility for us. For example, it does not allow disabling conversation propagation for certain pages and/or resources. This patch lets the enum implement an interface to give it the flexibility we needed without breaking the API for others.
